### PR TITLE
Insert the object, rather than the presentation.

### DIFF
--- a/reorderable_list_model.py
+++ b/reorderable_list_model.py
@@ -151,7 +151,7 @@ class ReorderableListModel(QtCore.QAbstractListModel):
             if index < row:
                 target_row += 1
             self.beginInsertRows(QtCore.QModelIndex(), target_row, target_row)
-            self.nodes.insert(target_row, text)
+            self.nodes.insert(target_row, self.nodes[index])
             self.endInsertRows()
             self.lastDroppedItems.append(text)
             row += 1


### PR DESCRIPTION
In my opinion this is a very good example of something that just works on the simple case but requires deeper investigation why it would not work for the general case, for example resenting a list of objects within a listview. I think there is a very small change that would abstract what has been viewed towards what has been stored. I have wondered by you did not just send the index, opposed to something that is likely to be unique such as the name of an item. I think the suggestion below is a no regret. It replaces the "text" with the actual node contents, so getData could be presentation (hopefully unique) and the actual placement would place the found object not merely its presentation. A more revamped approach would be sending the object hash as mime and searching for the hash.